### PR TITLE
Update dependencies to hopefully fix deprecated Octokit.plugin() call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@octokit/core": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.4.2.tgz",
-      "integrity": "sha512-fUx/Qt774cgiPhb3HRKfdl6iufVL/ltECkwkCg373I4lIPYvAPY4cbidVZqyVqHI+ThAIlFlTW8FT4QHChv3Sg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.4.3.tgz",
+      "integrity": "sha512-9T91nYeBB7+PNK3oxOuA+6DXCPRvhJ80ke+NqhXirBjVtNepTKFJXoWPqguRSBQ+dkEVA8dZJMxfFzjz9yhiuA==",
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
@@ -26,9 +26,9 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.3.tgz",
-      "integrity": "sha512-EzKwkwcxeegYYah5ukEeAI/gYRLv2Y9U5PpIsseGSFDk+G3RbipQGBs8GuYS1TLCtQaqoO66+aQGtITPalxsNQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.0.tgz",
+      "integrity": "sha512-3nx+MEYoZeD0uJ+7F/gvELLvQJzLXhep2Az0bBSXagbApDvDW0LWwpnAIY/hb0Jwe17A0fJdz0O12dPh05cj7A==",
       "requires": {
         "@octokit/types": "^2.0.0",
         "is-plain-object": "^3.0.0",
@@ -56,9 +56,9 @@
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.0.1.tgz",
-      "integrity": "sha512-xtW3AQoGDD0un/AkPjIndTdFO+O/My0I15TArvrbJirBCV91R1ElrE3gRcsUJENP3t/vveiQ9C6XQjo9sS2xQg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.0.2.tgz",
+      "integrity": "sha512-HzODcSUt9mjErly26TlTOGZrhf9bmF/FEDQ2zln1izhgmIV6ulsjsHmgmR4VZ0wzVr/m52Eb6U2XuyS8fkcR1A==",
       "requires": {
         "@octokit/types": "^2.0.1"
       }
@@ -69,21 +69,21 @@
       "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.2.0.tgz",
-      "integrity": "sha512-k+RLsegQn4s0wvAFYuk3R18FVKRg3ktvzIGW6MkmrSiSXBwYfaEsv4CuPysyef0DL+74DRj/X9MLJYlbleUO+Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.4.0.tgz",
+      "integrity": "sha512-Tvctk0u5SVrSLAzi8SLo0KrLSBl5biAHBgWy3L65vsbO/2fjzr62HVkoDPyr+WRT+eHhhqpKAERF3dQWOIUOvQ==",
       "requires": {
         "@octokit/types": "^2.0.1",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.2.tgz",
-      "integrity": "sha512-7NPJpg19wVQy1cs2xqXjjRq/RmtSomja/VSWnptfYwuBxLdbYh2UjhGi0Wx7B1v5Iw5GKhfFDQL7jM7SSp7K2g==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.4.tgz",
+      "integrity": "sha512-qyj8G8BxQyXjt9Xu6NvfvOr1E0l35lsXtwm3SopsYg/JWXjlsnwqLc8rsD2OLguEL/JjLfBvrXr4az7z8Lch2A==",
       "requires": {
-        "@octokit/endpoint": "^5.5.0",
-        "@octokit/request-error": "^1.0.1",
+        "@octokit/endpoint": "^6.0.0",
+        "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
@@ -93,9 +93,9 @@
       }
     },
     "@octokit/request-error": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
-      "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
       "requires": {
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
@@ -103,28 +103,28 @@
       }
     },
     "@octokit/rest": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.0.0.tgz",
-      "integrity": "sha512-nSlmyy1DBEOsC4voRbk/SN56V/iuZfxZzjFFz+ocb2MAYwHC+z1TyVOMV9W630dVn9ukioJO34VD5NSYwcgFWg==",
+      "version": "17.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.1.4.tgz",
+      "integrity": "sha512-LGghhepxoXyvi7ew0OdedrlwXQog8gvTbcdXoQ6RDKnzoYW2rBpcqeWC4fTuPUp9K0UEykcMix8kFnQ5b+64JQ==",
       "requires": {
-        "@octokit/core": "^2.4.0",
+        "@octokit/core": "^2.4.3",
         "@octokit/plugin-paginate-rest": "^2.0.0",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^3.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "3.4.0"
       }
     },
     "@octokit/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-iEeW3XlkxeM/CObeoYvbUv24Oe+DldGofY+3QyeJ5XKKA6B+V94ePk14EDCarseWdMs6afKZPv3dFq8C+SY5lw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.1.tgz",
+      "integrity": "sha512-q4Wr7RexkPRrkQpXzUYF5Fj/14Mr65RyOHj6B9d/sQACpqGcStkHZj4qMEtlMY5SnD/69jlL9ItGPbDM0dR/dA==",
       "requires": {
         "@types/node": ">= 8"
       }
     },
     "@types/node": {
-      "version": "13.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
-      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw=="
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
+      "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ=="
     },
     "before-after-hook": {
       "version": "2.1.0",
@@ -220,9 +220,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -297,9 +297,9 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/tadodotcom/gh-release-cli#readme",
   "dependencies": {
-    "@octokit/rest": "~17.0.0",
-    "minimist": "~1.2.0",
+    "@octokit/rest": "~17.1.4",
+    "minimist": "~1.2.5",
     "mime-types": "~2.1.26"
   }
 }


### PR DESCRIPTION
See bug issue for more details here: https://github.com/tadodotcom/energy-savings-report/issues/212 

Hard to say if this will fix it. We don't use Octokit.plugin() ourself and documentation on this topic is very sparse. 

@ankittado , you once set up a local version of this to create a release on one of your repositories. If you have it at hand please test this PR on that, if not I would just try it out directly with the ESR. This minor version update shouldn't do any harm *fingerscrossed* 😅